### PR TITLE
feat: Add block to set showOnMap for Owl Trackers

### DIFF
--- a/src/behaviors/impl/extensions.ts
+++ b/src/behaviors/impl/extensions.ts
@@ -428,6 +428,23 @@ export const EXTENSIONS_BEHAVIORS = {
         signal.throwIfAborted();
     },
 
+    setOwlTrackerShowOnMap: async (
+        signal: AbortSignal,
+        selfIdUnknown: unknown,
+        fieldNameUnknown: unknown,
+        showUnknown: unknown,
+    ): Promise<void> => {
+        const show = Boolean(showUnknown);
+        await ItemProxy.getInstance().update(String(selfIdUnknown), (draft) => {
+            OwlTrackers.setFieldShowOnMap(
+                draft,
+                String(fieldNameUnknown),
+                show,
+            );
+        });
+        signal.throwIfAborted();
+    },
+
     // Google Sheets
     getSheetsValue: async (
         signal: AbortSignal,

--- a/src/blockly/BehaviorJavascriptGenerator.ts
+++ b/src/blockly/BehaviorJavascriptGenerator.ts
@@ -52,6 +52,7 @@ import {
     BLOCK_EXTENSION_OWL_TRACKERS_FIELD,
     BLOCK_EXTENSION_OWL_TRACKERS_SET_CHECKBOX,
     BLOCK_EXTENSION_OWL_TRACKERS_SET_FIELD,
+    BLOCK_EXTENSION_OWL_TRACKERS_SET_SHOW_ON_MAP,
     BLOCK_EXTENSION_PHASE_CHANGE,
     BLOCK_EXTENSION_PRETTY_SET_INITIATIVE,
     BLOCK_EXTENSION_RUMBLE_ROLL,
@@ -2564,6 +2565,25 @@ const GENERATORS: Record<CustomBlockType | OverriddenBlockType, Generator> = {
             PARAMETER_SELF_ID,
             fieldName,
             checked,
+        )};\n`;
+    },
+
+    extension_owl_trackers_set_show_on_map: (block, generator) => {
+        const fieldName = generator.valueToCode(
+            block,
+            BLOCK_EXTENSION_OWL_TRACKERS_SET_SHOW_ON_MAP.args0[2].name,
+            javascript.Order.NONE,
+        );
+        const show = getStringFieldValue(
+            block,
+            BLOCK_EXTENSION_OWL_TRACKERS_SET_SHOW_ON_MAP.args0[1].name,
+        );
+        return `await ${behave(
+            "setOwlTrackerShowOnMap",
+            PARAMETER_SIGNAL,
+            PARAMETER_SELF_ID,
+            fieldName,
+            show,
         )};\n`;
     },
 

--- a/src/blockly/blocks.ts
+++ b/src/blockly/blocks.ts
@@ -51,6 +51,39 @@ export const BLOCK_GLIDE = {
     inputsInline: true,
 } as const;
 
+export const BLOCK_EXTENSION_OWL_TRACKERS_SET_SHOW_ON_MAP = {
+    style: "extension_blocks",
+    type: "extension_owl_trackers_set_show_on_map",
+    tooltip:
+        "Set whether a field is shown on the map in the Owl Trackers extension",
+    message0: "%1 %2 field %3 on map",
+    args0: [
+        {
+            type: "field_image",
+            src: "https://owl-trackers.onrender.com/owl-trackers-logo.svg",
+            width: 24,
+            height: 24,
+            alt: "Owl Trackers extension icon",
+        },
+        {
+            type: "field_dropdown",
+            name: "ACTION",
+            options: [
+                ["show", "true"],
+                ["hide", "false"],
+            ],
+        },
+        {
+            type: "input_value",
+            name: "FIELD",
+            check: ["String", "Number"],
+        },
+    ],
+    previousStatement: null,
+    nextStatement: null,
+    inputsInline: true,
+} as const;
+
 export const BLOCK_GLIDE_ROTATE_LEFT = {
     style: "motion_blocks",
     type: "motion_glide_turnleft",
@@ -3529,6 +3562,7 @@ export const CUSTOM_JSON_BLOCKS = [
     BLOCK_EXTENSION_OWL_TRACKERS_CHECKBOX,
     BLOCK_EXTENSION_OWL_TRACKERS_SET_FIELD,
     BLOCK_EXTENSION_OWL_TRACKERS_SET_CHECKBOX,
+    BLOCK_EXTENSION_OWL_TRACKERS_SET_SHOW_ON_MAP,
     BLOCK_EXTENSION_CODEO_RUN_SCRIPT,
     BLOCK_EXTENSION_SHEETS_GET,
     BLOCK_EXTENSION_WEATHER_ADD,

--- a/src/blockly/toolbox.ts
+++ b/src/blockly/toolbox.ts
@@ -57,6 +57,7 @@ import {
     BLOCK_EXTENSION_OWL_TRACKERS_FIELD,
     BLOCK_EXTENSION_OWL_TRACKERS_SET_CHECKBOX,
     BLOCK_EXTENSION_OWL_TRACKERS_SET_FIELD,
+    BLOCK_EXTENSION_OWL_TRACKERS_SET_SHOW_ON_MAP,
     BLOCK_EXTENSION_PHASE_CHANGE,
     BLOCK_EXTENSION_PRETTY_MY_INITIATIVE,
     BLOCK_EXTENSION_PRETTY_MY_TURN,
@@ -1011,6 +1012,14 @@ export function createToolbox(target: BehaviorItem, grid: GridParsed) {
                     },
 
                     ...extensionHeader("Owl Trackers"),
+                    {
+                        kind: "block",
+                        type: BLOCK_EXTENSION_OWL_TRACKERS_SET_SHOW_ON_MAP.type,
+                        inputs: {
+                            [BLOCK_EXTENSION_OWL_TRACKERS_SET_SHOW_ON_MAP
+                                .args0[2].name]: shadowDynamic("HP"),
+                        },
+                    },
                     {
                         kind: "block",
                         type: BLOCK_EXTENSION_OWL_TRACKERS_SET_FIELD.type,

--- a/src/extensions/OwlTrackers.ts
+++ b/src/extensions/OwlTrackers.ts
@@ -7,6 +7,7 @@ interface BaseTracker {
     readonly id: string;
     readonly color: number;
     readonly name?: string;
+    readonly showOnMap?: boolean;
 }
 
 interface NumberTracker extends BaseTracker {
@@ -98,5 +99,22 @@ export const OwlTrackers = {
         }
 
         item.metadata[METADATA_KEY] = trackers;
+    },
+
+    setFieldShowOnMap: (
+        item: Draft<Item>,
+        fieldName: string,
+        show: boolean,
+    ): void => {
+        const trackers =
+            (item.metadata[METADATA_KEY] as Draft<OwlTracker[] | undefined>) ??
+            [];
+
+        const tracker = trackers.find((t) => t.name === fieldName);
+
+        if (tracker) {
+            tracker.showOnMap = show;
+            item.metadata[METADATA_KEY] = trackers;
+        }
     },
 };


### PR DESCRIPTION
This commit introduces a new block for the Owl Trackers extension that allows setting the `showOnMap` property for a tracker. The block is styled as '<dropdown show/hide> field <field name input> on map'. This enhancement provides users with more granular control over the visibility of their trackers on the map.

Based on user feedback, this commit also ensures that the tracker is not created if it doesn't exist, and the `showUnknown` parameter is correctly interpreted as a boolean.